### PR TITLE
Use a proper check for Bacon v2

### DIFF
--- a/src/Google2FA.php
+++ b/src/Google2FA.php
@@ -97,7 +97,7 @@ class Google2FA extends Google2FAPackage
     public function qrCodeServiceFactory()
     {
         if (
-            class_exists('BaconQrCode\Writer') ||
+            class_exists('BaconQrCode\Writer') &&
             class_exists('BaconQrCode\Renderer\ImageRenderer')
         ) {
             return new Bacon();


### PR DESCRIPTION
I believe we should be checking that both of these classes exist, not either of them. Bacon 1 only has Writer, but Bacon 2 (which this package targets) has Writer AND ImageRenderer.