### PR TITLE
Chillerlan fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This is package is [Goole2FA](https://github.com/antonioribeiro/google2fa) integ
  
 ## Requirements
 
-- PHP 5.4+
+- PHP 7.1+
 
 ## Installing
 
@@ -43,7 +43,7 @@ return $google2fa->generateSecretKey();
 
 ## Generating QRCodes
 
-The securer way of creating QRCode is to do it yourself or using a library. First you have to install the BaconQrCode package, as stated above, then you just have to generate the inline string using:
+The securer way of creating QRCode is to do it yourself or using a library. First you have to install the Chillerlan or BaconQrCode package, then you just have to generate the inline string using:
  
 ```php
 $inlineUrl = $google2fa->getQRCodeInline(

--- a/src/Google2FA.php
+++ b/src/Google2FA.php
@@ -2,18 +2,14 @@
 
 namespace PragmaRX\Google2FAQRCode;
 
-use BaconQrCode\Writer;
-use BaconQrCode\Renderer\Image\Png;
 use BaconQrCode\Renderer\ImageRenderer;
+use BaconQrCode\Writer;
+use chillerlan\QRCode\QRCode;
+use PragmaRX\Google2FA\Google2FA as Google2FAPackage;
+use PragmaRX\Google2FAQRCode\Exceptions\MissingQrCodeServiceException;
 use PragmaRX\Google2FAQRCode\QRCode\Bacon;
 use PragmaRX\Google2FAQRCode\QRCode\Chillerlan;
-use BaconQrCode\Renderer\Image\RendererInterface;
-use BaconQrCode\Writer as BaconQrCodeWriter;
-use BaconQrCode\Renderer\Image\ImagickImageBackEnd;
-use PragmaRX\Google2FA\Google2FA as Google2FAPackage;
-use BaconQrCode\Renderer\RendererStyle\RendererStyle;
-use BaconQrCode\Renderer\Image\ImageBackEndInterface;
-use PragmaRX\Google2FAQRCode\Exceptions\MissingQrCodeServiceException;
+use PragmaRX\Google2FAQRCode\QRCode\QRCodeServiceContract;
 
 class Google2FA extends Google2FAPackage
 {
@@ -25,9 +21,9 @@ class Google2FA extends Google2FAPackage
     /**
      * Google2FA constructor.
      *
-     * @param ImageBackEndInterface|RendererInterface|null $imageBackEnd
+     * @param \PragmaRX\Google2FAQRCode\QRCode\QRCodeServiceContract|null $qrCodeService
      */
-    public function __construct($qrCodeService = null)
+    public function __construct(?QRCodeServiceContract $qrCodeService = null)
     {
         $this->setQrCodeService(
             empty($qrCodeService)
@@ -80,6 +76,7 @@ class Google2FA extends Google2FAPackage
     /**
      * Service setter
      *
+     * @param \PragmaRX\Google2FAQRCode\QRCode\QRCodeServiceContract $service
      * @return self
      */
     public function setQrCodeService($service)
@@ -97,16 +94,13 @@ class Google2FA extends Google2FAPackage
     public function qrCodeServiceFactory()
     {
         if (
-            class_exists('BaconQrCode\Writer') ||
-            class_exists('BaconQrCode\Renderer\ImageRenderer')
+            class_exists(Writer::class) ||
+            class_exists(ImageRenderer::class)
         ) {
             return new Bacon();
         }
 
-        if (
-            class_exists('chillerlan\QRCode') ||
-            class_exists('BaconQrCode\Renderer\ImageRenderer')
-        ) {
+        if (class_exists(QRCode::class)) {
             return new Chillerlan();
         }
 

--- a/src/Google2FA.php
+++ b/src/Google2FA.php
@@ -18,7 +18,7 @@ use PragmaRX\Google2FAQRCode\Exceptions\MissingQrCodeServiceException;
 class Google2FA extends Google2FAPackage
 {
     /**
-     * @var ImageBackEndInterface|RendererInterface|null $imageBackEnd
+     * @var \PragmaRX\Google2FAQRCode\QRCode\QRCodeServiceContract $qrCodeService
      */
     protected $qrCodeService;
 

--- a/src/QRCode/Chillerlan.php
+++ b/src/QRCode/Chillerlan.php
@@ -66,7 +66,6 @@ class Chillerlan implements QRCodeServiceContract
     {
         $renderer = new QRCode($this->getOptions());
 
-        return "data:image/svg+xml;base64," .
-            base64_encode($renderer->render($string));
+        return $renderer->render($string);
     }
 }

--- a/src/QRCode/Chillerlan.php
+++ b/src/QRCode/Chillerlan.php
@@ -4,7 +4,6 @@ namespace PragmaRX\Google2FAQRCode\QRCode;
 
 use chillerlan\QRCode\QRCode;
 use chillerlan\QRCode\QROptions;
-use BaconQrCode\Writer as BaconQrCodeWriter;
 
 class Chillerlan implements QRCodeServiceContract
 {
@@ -13,7 +12,6 @@ class Chillerlan implements QRCodeServiceContract
     /**
      * Get QRCode options.
      *
-     * @param int $size
      * @return \chillerlan\QRCode\QROptions
      */
     protected function getOptions()
@@ -29,7 +27,7 @@ class Chillerlan implements QRCodeServiceContract
      * @param array $options
      * @return self
      */
-    protected function setOptions($options)
+    public function setOptions($options)
     {
         $this->options = $options;
 


### PR DESCRIPTION
This PR contains a couple of fixes:

1. The Chillerlan adapter implementation currently produces a broken SVG QR code as the underlying Chillerlan implementation already does the base64 encode by default and the Chillerlan adapter in this package base64 encodes an already base64 encoded output. There is a test which asserts the expected output but it's failing (and now it passes again with this fix). It looks like the Travis CI pipeline is not running at all, otherwise this would've been caught a lot sooner as it never worker properly.
2. Without this fix I thought I could override the `imageBase64` option of the underlying Chillerlan implementation so that it doesn't do the base64 encode as this package already does it, but the `\PragmaRX\Google2FAQRCode\QRCode\Chillerlan::setOptions` method is for some reason protected which makes it unusable. I've chaged the visibility to `public`.

In the meantime I've worked around this in my Laravel project by using an anonymous class which overrides the `$options` array.

```php
$this->app->bind(Google2FA::class, function (): Google2FA {
    $chillerlan = new class() extends Chillerlan {
        protected $options = ['imageBase64' => false];
    };

    return new Google2FA($chillerlan);
});
```

3. I've fixed some docblock issues, the Chillerlan `class_exists` check which also checks for the `BaconQrCode\Renderer\ImageRenderer` class existence which doesn't make sense and I've updated the README.md (the PHP requirement is fixed).