### PR TITLE
Chillerlan fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This is package is [Goole2FA](https://github.com/antonioribeiro/google2fa) integ
  
 ## Requirements
 
-- PHP 5.4+
+- PHP 7.1+
 
 ## Installing
 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "phpunit/phpunit": "~4|~5|~6|~7|~8|~9",
         "khanamiryan/qrcode-detector-decoder": "^1.0",
         "bacon/bacon-qr-code": "^2.0",
-        "chillerlan/php-qrcode": "^1.0|^2.0|^3.0|^4.0"
+        "chillerlan/php-qrcode": "^2.0|^3.0|^4.0"
     },
      "autoload": {
         "psr-4": {

--- a/src/QRCode/Chillerlan.php
+++ b/src/QRCode/Chillerlan.php
@@ -4,7 +4,6 @@ namespace PragmaRX\Google2FAQRCode\QRCode;
 
 use chillerlan\QRCode\QRCode;
 use chillerlan\QRCode\QROptions;
-use BaconQrCode\Writer as BaconQrCodeWriter;
 
 class Chillerlan implements QRCodeServiceContract
 {

--- a/src/QRCode/Chillerlan.php
+++ b/src/QRCode/Chillerlan.php
@@ -48,6 +48,8 @@ class Chillerlan implements QRCodeServiceContract
             'version' => QRCode::VERSION_AUTO,
             'outputType' => QRCode::OUTPUT_MARKUP_SVG,
             'eccLevel' => QRCode::ECC_L,
+            // as per https://github.com/antonioribeiro/google2fa-qrcode/pull/11#issuecomment-778500498
+            'imageBase64' => false,
         ];
 
         return array_merge($defaults, $this->options);

--- a/src/QRCode/Chillerlan.php
+++ b/src/QRCode/Chillerlan.php
@@ -47,11 +47,14 @@ class Chillerlan implements QRCodeServiceContract
             'version' => QRCode::VERSION_AUTO,
             'outputType' => QRCode::OUTPUT_MARKUP_SVG,
             'eccLevel' => QRCode::ECC_L,
-            // as per https://github.com/antonioribeiro/google2fa-qrcode/pull/11#issuecomment-778500498
-            'imageBase64' => false,
         ];
 
-        return array_merge($defaults, $this->options);
+	    // as per https://github.com/antonioribeiro/google2fa-qrcode/pull/11#issuecomment-778500498
+        $options = array_merge($defaults, $this->options);
+
+	    $options['imageBase64'] = false;
+
+        return $options;
     }
 
     /**


### PR DESCRIPTION
Supercedes #11 

- fixes the base64 output and lets this library handle it
- removes v1.x from composer.json as this is a php5 backport of v2.x (originally exclusive for the Drupal project)
- removes unused import

Further i'd recommend to remove outdated PHPUnit versions from composer.json. IIRC 7.5 is the latest that supports PHP 7.1.