### PR TITLE
Add missing import for interface

### DIFF
--- a/src/Google2FA.php
+++ b/src/Google2FA.php
@@ -7,6 +7,7 @@ use BaconQrCode\Renderer\Image\Png;
 use BaconQrCode\Renderer\ImageRenderer;
 use PragmaRX\Google2FAQRCode\QRCode\Bacon;
 use PragmaRX\Google2FAQRCode\QRCode\Chillerlan;
+use PragmaRX\Google2FAQRCode\QRCode\QRCodeServiceContract;
 use BaconQrCode\Renderer\Image\RendererInterface;
 use BaconQrCode\Writer as BaconQrCodeWriter;
 use BaconQrCode\Renderer\Image\ImagickImageBackEnd;


### PR DESCRIPTION
The import of this interface is missing causing developertools such as PHPStan to fail its checks because it thinks the interface is in the same namespace as the `Google2FA` class.

Adding the missing import should resolve this issue.