### PR TITLE
change methods case for consistency with Google2FA library

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ $valid = $google2fa->verifyKey($user->google2fa_secret, $secret);
 If you want to use a different service, you just have to 
 
 ```php
-$google2fa->setQrcodeService(new YourService())
+$google2fa->setQRCodeService(new YourService())
           ->getQRCodeInline(
               $companyName,
               $companyEmail,
@@ -116,7 +116,7 @@ Beginning on version 2.0 the rendering service is optional, so you have to manua
 ## Using a diffent image backend
 
 ```php
-$google2fa->setQrcodeService(
+$google2fa->setQRCodeService(
     new \PragmaRX\Google2FAQRCode\QRCode\Bacon(
         new \BaconQrCode\Renderer\Image\SvgImageBackEnd()
     )

--- a/src/Exceptions/MissingQRCodeServiceException.php
+++ b/src/Exceptions/MissingQRCodeServiceException.php
@@ -4,6 +4,6 @@ namespace PragmaRX\Google2FAQRCode\Exceptions;
 
 use Exception;
 
-class MissingQrCodeServiceException extends Exception
+class MissingQRCodeServiceException extends Exception
 {
 }

--- a/src/Google2FA.php
+++ b/src/Google2FA.php
@@ -14,7 +14,7 @@ use BaconQrCode\Renderer\Image\ImagickImageBackEnd;
 use PragmaRX\Google2FA\Google2FA as Google2FAPackage;
 use BaconQrCode\Renderer\RendererStyle\RendererStyle;
 use BaconQrCode\Renderer\Image\ImageBackEndInterface;
-use PragmaRX\Google2FAQRCode\Exceptions\MissingQrCodeServiceException;
+use PragmaRX\Google2FAQRCode\Exceptions\MissingQRCodeServiceException;
 
 class Google2FA extends Google2FAPackage
 {
@@ -31,7 +31,7 @@ class Google2FA extends Google2FAPackage
      */
     public function __construct($qrCodeService = null, $imageBackEnd = null)
     {
-        $this->setQrCodeService(
+        $this->setQRCodeService(
             empty($qrCodeService)
                 ? $this->qrCodeServiceFactory($imageBackEnd)
                 : $qrCodeService
@@ -56,8 +56,8 @@ class Google2FA extends Google2FAPackage
         $size = 200,
         $encoding = 'utf-8'
     ) {
-        if (empty($this->getQrCodeService())) {
-            throw new MissingQrCodeServiceException(
+        if (empty($this->getQRCodeService())) {
+            throw new MissingQRCodeServiceException(
                 'You need to install a service package or assign yourself the service to be used.'
             );
         }
@@ -74,7 +74,7 @@ class Google2FA extends Google2FAPackage
      *
      * @return \PragmaRX\Google2FAQRCode\QRCode\QRCodeServiceContract
      */
-    public function getQrCodeService()
+    public function getQRCodeService()
     {
         return $this->qrCodeService;
     }
@@ -84,7 +84,7 @@ class Google2FA extends Google2FAPackage
      *
      * @return self
      */
-    public function setQrCodeService($service)
+    public function setQRCodeService($service)
     {
         $this->qrCodeService = $service;
 

--- a/tests/Google2FATest.php
+++ b/tests/Google2FATest.php
@@ -2,14 +2,12 @@
 
 namespace PragmaRX\Google2FAQRCode\Tests;
 
+use PHPUnit\Framework\TestCase;
+use PragmaRX\Google2FAQRCode\Exceptions\MissingQRCodeServiceException;
+use PragmaRX\Google2FAQRCode\Google2FA;
 use PragmaRX\Google2FAQRCode\QRCode\Bacon;
 use PragmaRX\Google2FAQRCode\QRCode\Chillerlan;
-use BaconQrCode\Renderer\Image\ImagickImageBackEnd;
-use BaconQrCode\Renderer\Image\Png;
-use PHPUnit\Framework\TestCase;
-use PragmaRX\Google2FAQRCode\Google2FA;
 use Zxing\QrReader;
-use PragmaRX\Google2FAQRCode\Exceptions\MissingQrCodeServiceException;
 
 class Google2FATest extends TestCase
 {
@@ -38,11 +36,11 @@ class Google2FATest extends TestCase
 
     public function testQrcodeServiceMissing()
     {
-        $this->expectException(MissingQrCodeServiceException::class);
+        $this->expectException(MissingQRCodeServiceException::class);
 
-        $this->google2fa->setQrcodeService(null);
+        $this->google2fa->setQRCodeService(null);
 
-        $this->getQrCode();
+        $this->getQRCode();
     }
 
     public function testQrcodeInlineBacon()
@@ -53,7 +51,7 @@ class Google2FATest extends TestCase
             return;
         }
 
-        $this->google2fa->setQrcodeService(new Bacon());
+        $this->google2fa->setQRCodeService(new Bacon());
 
         $this->assertEquals(
             static::OTP_URL,
@@ -70,7 +68,7 @@ class Google2FATest extends TestCase
 
     public function testQrcodeInlineChillerlan()
     {
-        $this->google2fa->setQrcodeService(new Chillerlan());
+        $this->google2fa->setQRCodeService(new Chillerlan());
 
         $this->assertStringStartsWith(
             'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMj',
@@ -78,7 +76,7 @@ class Google2FATest extends TestCase
         );
     }
 
-    public function getQrCode()
+    public function getQRCode()
     {
         return $this->google2fa->getQRCodeInline(
             'PragmaRX',


### PR DESCRIPTION
The PR seeks to match the QRCODE case used by the original Google2FA library that is wrapped by this repository.

I'm aware that this causes breaking changes for the version upgrade. It should be treated as a major version change in the future if one intends to merge the PR.